### PR TITLE
Add support for the Logs API endpoint

### DIFF
--- a/.github/workflows/commit_checks.yaml
+++ b/.github/workflows/commit_checks.yaml
@@ -14,10 +14,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'  # Specify a Python version explicitly
+          python-version: '3.13'  # Specify a Python version explicitly
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   test:
@@ -35,7 +35,7 @@ jobs:
       APIKEY: ${{ secrets.APIKEY }}
       DOMAIN: ${{ secrets.DOMAIN }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Required for setuptools-scm
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Initial triage
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -11,14 +11,14 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Build package
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,12 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.gitignore
+++ b/.gitignore
@@ -300,5 +300,3 @@ dev/
 
 # pytest cache
 pytestdebug.log
-
-*/_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,6 @@ cython_debug/
 __pycache__
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
-../../../mentor/kupriienko/airtable-notify/.env
 .anvil/*
 .elasticbeanstalk/*
 .env-mysql

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -66,7 +66,7 @@ repos:
         exclude: ^tests
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.2
+    rev: 0.34.0
     hooks:
       - id: check-github-workflows
 
@@ -77,7 +77,7 @@ repos:
 #        exclude: ^docs/
 
   - repo: https://github.com/akaihola/darker
-    rev: v2.1.1
+    rev: v3.0.0
     hooks:
       - id: darker
 
@@ -103,7 +103,7 @@ repos:
         exclude: ^tests
 
   - repo: https://github.com/PyCQA/pylint
-    rev: v3.3.7
+    rev: v3.3.8
     hooks:
       - id: pylint
         args:
@@ -117,7 +117,7 @@ repos:
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.2
+    rev: v0.13.1
     hooks:
       # Run the linter.
       - id: ruff
@@ -133,12 +133,12 @@ repos:
         additional_dependencies: [tomli]
 
   -   repo: https://github.com/dosisod/refurb
-      rev: v2.1.0
+      rev: v2.2.0
       hooks:
       -   id: refurb
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.1
+    rev: v1.18.2
     hooks:
     -   id: mypy
         args: [--config-file=./pyproject.toml]
@@ -147,7 +147,7 @@ repos:
         exclude: ^mailgun/examples/
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.402
+    rev: v1.1.405
     hooks:
     - id: pyright
 
@@ -161,7 +161,7 @@ repos:
         additional_dependencies: [".[toml]"]
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.33.1
+    rev: v1.36.2
     hooks:
       - id: typos
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,7 @@ repos:
     rev: v3.0.0
     hooks:
       - id: darker
+        additional_dependencies: [black]
 
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ We [keep a changelog.](http://keepachangelog.com/)
 
 ## [Unreleased]
 
-## [1.2.0] - 2025-09-XX
+## [1.2.0] - 2025-10-02
 
 ### Added
 
@@ -15,11 +15,13 @@ We [keep a changelog.](http://keepachangelog.com/)
   - Add `Get account logs` sections with an example to `README.md`
   - Add class `LogsTest` to tests/tests.py
 - Add `black` to `darker`'s additional_dependencies in `.pre-commit-config.yaml`
+- Add docstrings to the test classes.
 
 ### Changed
 
 - Update pre-commit hooks to the latest versions
 - Fix indentation of the `post_bounces()` example in `README.md`
+- Fix some pylint warnings related to docstrings
 
 ## Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We [keep a changelog.](http://keepachangelog.com/)
 - Update pre-commit hooks to the latest versions
 - Fix indentation of the `post_bounces()` example in `README.md`
 - Fix some pylint warnings related to docstrings
+- Update CI workflows
 
 ## Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,4 +86,4 @@ We [keep a changelog.](http://keepachangelog.com/)
 [1.0.1]: https://github.com/mailgun/mailgun-python/releases/tag/v1.0.1
 [1.0.2]: https://github.com/mailgun/mailgun-python/releases/tag/v1.0.2
 [1.1.0]: https://github.com/mailgun/mailgun-python/releases/tag/v1.1.0
-[unreleased]: https://github.com/mailgun/mailgun-python/releases/tag/v1.1.0...HEAD
+[unreleased]: https://github.com/mailgun/mailgun-python/compare/v1.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ We [keep a changelog.](http://keepachangelog.com/)
 - Update pre-commit hooks to the latest versions
 - Fix indentation of the `post_bounces()` example in `README.md`
 
+## Removed
+
+- Remove `*/_version.py` from `.gitignore`
+
 ### Pull Requests Merged
 
 - [PR_18](https://github.com/mailgun/mailgun-python/pull/18) - Add support for the Logs API endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ We [keep a changelog.](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-09-XX
+
+### Added
+
+- Add the Logs endpoint:
+  - Add `logs` to the `analytics` key of special cases
+  - Add `mailgun/examples/logs_examples.py` with `post_analytics_logs()`
+  - Add class `LogsTest` to tests/tests.py
+  - Add `Get account logs` sections with an example to `README.md`
+  - Add class `LogsTest` to tests/tests.py
+- Add `black` to `darker`'s additional_dependencies in `.pre-commit-config.yaml`
+
+### Changed
+
+- Update pre-commit hooks to the latest versions
+- Fix indentation of the `post_bounces()` example in `README.md`
+
+### Pull Requests Merged
+
+- [PR_18](https://github.com/mailgun/mailgun-python/pull/18) - Add support for the Logs API endpoint
+
 ## [1.1.0] - 2025-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ def post_analytics_logs() -> None:
 ### Metrics
 
 Mailgun collects many different events and generates event metrics which are available in your Control Panel.
-This data is also available via our analytics metrics [API endpoint](https://documentation.mailgun.com/docs/mailgun/api-reference/openapi-final/tag/Metrics/#tag/Metrics).
+This data is also available via our analytics metrics [API endpoint](https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/metrics).
 
 #### Get account metrics
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Check out all the resources and Python code examples in the official [Mailgun Do
     - [Events](#events)
       - [Retrieves a paginated list of events](#retrieves-a-paginated-list-of-events)
       - [Get events by recipient](#get-events-by-recipient)
+    - [Logs](#logs)
+      - [List logs](#list-logs)
     - [Metrics](#metrics)
       - [Get account metrics](#get-account-metrics)
       - [Get account usage metrics](#get-account-usage-metrics)
@@ -549,6 +551,17 @@ def events_by_recipient() -> None:
     req = client.events.get(domain=domain, filters=params)
     print(req.json())
 ```
+
+### Logs
+
+Mailgun keeps track of every inbound and outbound message event and stores this log data.
+This data can be queried and filtered to provide insights into the health of your email infrastructure [API endpoint](https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/logs/post-v1-analytics-logs).
+
+#### List Logs
+
+Gets customer event logs for an account.
+
+TODO: add an example.
 
 ### Metrics
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,36 @@ This data can be queried and filtered to provide insights into the health of you
 
 Gets customer event logs for an account.
 
-TODO: add an example.
+```python
+def post_analytics_logs() -> None:
+    """
+    # Metrics
+    # POST /analytics/logs
+    :return:
+    """
+
+    data = {
+        "start": "Wed, 24 Sep 2025 00:00:00 +0000",
+        "end": "Thu, 25 Sep 2025 00:00:00 +0000",
+        "filter": {
+            "AND": [
+                {
+                    "attribute": "domain",
+                    "comparator": "=",
+                    "values": [{"label": domain, "value": domain}],
+                }
+            ]
+        },
+        "include_subaccounts": True,
+        "pagination": {
+            "sort": "timestamp:asc",
+            "limit": 50,
+        },
+    }
+
+    req = client.analytics_logs.create(data=data)
+    print(req.json())
+```
 
 ### Metrics
 
@@ -665,14 +694,15 @@ domain: str = os.environ["DOMAIN"]
 
 client: Client = Client(auth=("api", key))
 
+
 def post_bounces() -> None:
-"""
-POST /<domain>/bounces
-:return:
-"""
-data = {"address": "test120@gmail.com", "code": 550, "error": "Test error"}
-req = client.bounces.create(data=data, domain=domain)
-print(req.json())
+    """
+    POST /<domain>/bounces
+    :return:
+    """
+    data = {"address": "test120@gmail.com", "code": 550, "error": "Test error"}
+    req = client.bounces.create(data=data, domain=domain)
+    print(req.json())
 ```
 
 #### Unsubscribe

--- a/mailgun/_version.py
+++ b/mailgun/_version.py
@@ -1,0 +1,12 @@
+"""
+Provides the version information for the package.
+
+This module is generated or managed by a versioning tool
+(setuptools_scm) to ensure a single source of truth
+for the package's version number.
+
+The `__version__` variable within this module holds the current
+version string of the package, formatted according to PEP 440.
+"""
+
+__version__ = "1.1.0"

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -119,7 +119,11 @@ class Config:
             "dkimkeys": {"base": v1_base, "keys": ["dkim", "keys"]},
             "domainlist": {"base": v4_base, "keys": ["domainlist"]},
             # /v1/analytics/metrics
-            "analytics": {"base": v1_base, "keys": ["analytics", "usage", "metrics"]},
+            # /v1/analytics/logs
+            "analytics": {
+                "base": v1_base,
+                "keys": ["analytics", "usage", "metrics", "logs"],
+            },
         }
 
         if key in special_cases:

--- a/mailgun/examples/logs_examples.py
+++ b/mailgun/examples/logs_examples.py
@@ -1,0 +1,42 @@
+import os
+
+from mailgun.client import Client
+
+
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
+client: Client = Client(auth=("api", key))
+
+
+def post_analytics_logs() -> None:
+    """
+    # Metrics
+    # POST /analytics/logs
+    :return:
+    """
+
+    data = {
+        "start": "Wed, 24 Sep 2025 00:00:00 +0000",
+        "end": "Thu, 25 Sep 2025 00:00:00 +0000",
+        "filter": {
+            "AND": [
+                {
+                    "attribute": "domain",
+                    "comparator": "=",
+                    "values": [{"label": domain, "value": domain}],
+                }
+            ]
+        },
+        "include_subaccounts": True,
+        "pagination": {
+            "sort": "timestamp:asc",
+            "limit": 50,
+        },
+    }
+
+    req = client.analytics_logs.create(data=data)
+    print(req.json())
+
+
+if __name__ == "__main__":
+    post_analytics_logs()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -15,6 +15,14 @@ from mailgun.client import Client
 
 
 class MessagesTests(unittest.TestCase):
+    """Tests for Mailgun Messages API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -25,7 +33,9 @@ class MessagesTests(unittest.TestCase):
         self.data: dict[str, str] = {
             "from": os.environ["MESSAGES_FROM"],
             "to": os.environ["MESSAGES_TO"],
-            # TODO: Check 'Domain $DOMAIN is not allowed to send: Free accounts are for test purposes only. Please upgrade or add the address to authorized recipients in Account Settings.'
+            # TODO: Check it:
+            # Domain $DOMAIN is not allowed to send: Free accounts are for test purposes only.
+            # Please upgrade or add the address to authorized recipients in Account Settings.
             # "cc": os.environ["MESSAGES_CC"],
             "subject": "Hello Vasyl Bodaj",
             "text": "Congratulations!, you just sent an email with Mailgun! You are truly awesome!",
@@ -42,10 +52,18 @@ class MessagesTests(unittest.TestCase):
 
 
 class DomainTests(unittest.TestCase):
-    """All the tests of this part will work only on fresh setup, or if you change self.test_domain variable every time you're running this again.
+    """Tests for Mailgun Domain API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    All the tests of this part will work only on fresh setup, or if you change self.test_domain variable every time you're running this again.
 
     It's happening because domain name is not deleting permanently after API call, so every new create will cause an error,
     as that domain is still exists. To avoid the problems we use a random domain name generator.
+
     """
 
     def setUp(self) -> None:
@@ -270,6 +288,14 @@ class DomainTests(unittest.TestCase):
     "Dedicated IPs should be enabled for the domain, see https://app.mailgun.com/settings/dedicated-ips"
 )
 class IpTests(unittest.TestCase):
+    """Tests for Mailgun IP API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -310,6 +336,14 @@ class IpTests(unittest.TestCase):
     "This feature can be disabled for an account, see https://app.mailgun.com/settings/ip-pools"
 )
 class IpPoolsTests(unittest.TestCase):
+    """Tests for Mailgun IP POOLS API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -369,6 +403,14 @@ class IpPoolsTests(unittest.TestCase):
 
 
 class EventsTests(unittest.TestCase):
+    """Tests for Mailgun Events API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -393,6 +435,14 @@ class EventsTests(unittest.TestCase):
 
 
 class TagsTests(unittest.TestCase):
+    """Tests for Mailgun Tags API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -459,6 +509,14 @@ class TagsTests(unittest.TestCase):
 
 
 class BouncesTests(unittest.TestCase):
+    """Tests for Mailgun Bounces API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -529,6 +587,14 @@ class BouncesTests(unittest.TestCase):
 
 
 class UnsubscribesTest(unittest.TestCase):
+    """Tests for Mailgun Unsubscribes API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -602,6 +668,14 @@ class UnsubscribesTest(unittest.TestCase):
 
 
 class ComplaintsTest(unittest.TestCase):
+    """Tests for Mailgun Complaints API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -680,6 +754,14 @@ class ComplaintsTest(unittest.TestCase):
 
 
 class WhiteListTest(unittest.TestCase):
+    """Tests for Mailgun WhiteList API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -731,6 +813,14 @@ class WhiteListTest(unittest.TestCase):
 
 
 class RoutesTest(unittest.TestCase):
+    """Tests for Mailgun Routes API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -869,6 +959,14 @@ class RoutesTest(unittest.TestCase):
 
 
 class WebhooksTest(unittest.TestCase):
+    """Tests for Mailgun Webhooks API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -925,6 +1023,14 @@ class WebhooksTest(unittest.TestCase):
 
 
 class MailingListsTest(unittest.TestCase):
+    """Tests for Mailgun Mailing Lists API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -1112,6 +1218,14 @@ class MailingListsTest(unittest.TestCase):
 
 
 class TemplatesTest(unittest.TestCase):
+    """Tests for Mailgun Templates API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -1281,6 +1395,14 @@ class TemplatesTest(unittest.TestCase):
     "Email Validation is only available through Mailgun paid plans, see https://www.mailgun.com/pricing/"
 )
 class EmailValidationTest(unittest.TestCase):
+    """Tests for Mailgun Email Validation API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -1333,6 +1455,14 @@ class EmailValidationTest(unittest.TestCase):
     "Inbox Placement is only available through Mailgun Optimize plans, see https://help.mailgun.com/hc/en-us/articles/360034702773-Inbox-Placement"
 )
 class InboxPlacementTest(unittest.TestCase):
+    """Tests for Mailgun Inbox Placement API.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",
@@ -1422,6 +1552,14 @@ class InboxPlacementTest(unittest.TestCase):
 
 
 class MetricsTest(unittest.TestCase):
+    """Tests for Mailgun Inbox Placement API, https://api.mailgun.net/v1/analytics/metrics.
+
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     # "https://api.mailgun.net/v1/analytics/metrics"
 
     def setUp(self) -> None:
@@ -1633,8 +1771,14 @@ class MetricsTest(unittest.TestCase):
 
 
 class LogsTest(unittest.TestCase):
-    # "https://api.mailgun.net/v1/analytics/logs"
+    """Tests for Mailgun Inbox Placement API, https://api.mailgun.net/v1/analytics/logs.
 
+    This class provides setup and teardown functionality for tests involving the
+    messages functionality, with authentication and client initialization handled
+    in `setUp`. Each test in this suite operates with the configured Mailgun client
+    instance to simulate API interactions.
+
+    """
     def setUp(self) -> None:
         self.auth: tuple[str, str] = (
             "api",


### PR DESCRIPTION
### Links:
- [Jira](https://mailgun.atlassian.net/browse/DE-1609)

### Actions:

- [x] Add the Logs endpoint:
  - [x] Add `logs` to the `analytics` key of special cases

- [x] Examples:
  - [x] Add `mailgun/examples/logs_examples.py` with `post_analytics_logs()`

- [x] Docs:
  - [x] Add `Get account logs` sections with an example to `README.md`
  - [x] Add docstrings to the test classes

- [x] Tests:
  - [x] Add class `LogsTest` to tests/tests.py 

- [x] CI:
  - [x] Update pre-commit hooks to the latest versions 
  - [x] Add `black` to `darker`'s additional_dependencies

- [x] Linting & Formatting:
  - [x] Fix some pylint warnings related to docstrings  

- [x] Package Management
  - [x] Remove `*/_version.py` from `.gitignore`
