### PR TITLE
Fix _client property in AsyncClient

### DIFF
--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -324,8 +324,7 @@ class AsyncClient(BaseClient):
                     )
 
                 self._httpx_client = httpx.AsyncClient(**kwargs)
-            return self._httpx_client
-        return None
+        return self._httpx_client
 
     async def aclose(self) -> None:
         """Close the underlying httpx.AsyncClient and purge memory."""


### PR DESCRIPTION
Fixed issue were AsyncClient._client returns None when  _client was initialized previously